### PR TITLE
Two tables with lots of data paginated both done different ways.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -29,6 +29,11 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources-jbossas-managed">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/.project
+++ b/.project
@@ -46,12 +46,12 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<name>tern.eclipse.ide.core.ternBuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>tern.eclipse.ide.core.ternBuilder</name>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
@@ -67,6 +67,5 @@
 		<nature>org.hibernate.eclipse.console.hibernateNature</nature>
 		<nature>org.jboss.tools.cdi.core.cdinature</nature>
 		<nature>org.jboss.tools.ws.jaxrs.nature</nature>
-		<nature>org.jboss.tools.jsf.jsfnature</nature>
 	</natures>
 </projectDescription>

--- a/src/main/java/ie/dit/onedirectory/rest/FailedCallDataREST.java
+++ b/src/main/java/ie/dit/onedirectory/rest/FailedCallDataREST.java
@@ -122,6 +122,10 @@ public class FailedCallDataREST {
 		return service.getAllIMSIWithCallFailuresBetweenDates(sqlDateFrom, sqlDateTo);
 	}
 
+	
+	// This method has been heavily modified to accommodate a hacky
+	// way of paginating a table. This is not the end result of this
+	// Needs refactored.
 	@GET
 	@Path("/count/{dates}")
 	@Produces(MediaType.APPLICATION_JSON)
@@ -131,13 +135,30 @@ public class FailedCallDataREST {
 		String[] dates = datesPassed.split("£");
 		String fromDate = dates[0];
 		String toDate = dates[1];
+		int indexFrom = Integer.parseInt(dates[2]);
+		int indexTo = Integer.parseInt(dates[3]);
+		
 		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
 		Date from = sdf.parse(fromDate);
 		SimpleDateFormat sdf1 = new SimpleDateFormat("yyyy-MM-dd");
 		Date to = sdf1.parse(toDate);
 		java.sql.Date sqlDateFrom = new java.sql.Date(from.getTime());
 		java.sql.Date sqlDateTo = new java.sql.Date(to.getTime());
-		return service.getCountBetweenDatesForAllIMSI(sqlDateFrom, sqlDateTo);
+		
+		ArrayList list = (ArrayList) service.getCountBetweenDatesForAllIMSI(sqlDateFrom, sqlDateTo);
+		
+		int length = list.size();
+		Collection listReturn = new ArrayList();
+		
+		if(length>10){
+			for(int i=indexFrom ; i<indexTo ; i++){
+				listReturn.add(list.get(i));
+			}
+		}
+		
+		return listReturn;
+		
+		
 	}
 
 	/**

--- a/src/main/webapp/NMEPage.jsp
+++ b/src/main/webapp/NMEPage.jsp
@@ -136,6 +136,10 @@
 var divs = ["imsiCount","modelCount"];
 var visibleDiv = null;
 var $modelTable = $('#tablePeter')
+var indexFrom=0;
+var indexTo=5
+var fromDate;
+var toDate;
 
 $(function(){
 	
@@ -185,13 +189,13 @@ function hideOtherDivs(){
 
  	removeData();
  	removeModelData();
-	var fromDate=$('#from').val();
-	var toDate=$('#to').val();
+	fromDate=$('#from').val();
+	toDate=$('#to').val();
 	var myurl;
 	var isValid=false;
 	
 	if(validateEntry(fromDate, toDate)){	
-		myurl='http://localhost:8080/project/rest/failedcalldata/count/'+fromDate+'Â£'+toDate;
+		myurl='http://localhost:8080/project/rest/failedcalldata/count/'+fromDate+'£'+toDate+'£0£5';
 		isValid=true;
 		}
 
@@ -282,8 +286,37 @@ function hideOtherDivs(){
  		button.addEventListener('click', removeData);
  		butDiv.appendChild(button);
  		$table.append(butDiv);
+
+ 		// This button added for pagination
+ 		// all logic in click method
+ 		var moreButton = document.createElement('button');
+ 		moreButton.setAttribute('class','btn btn-primary');
+ 		moreButton.innerHTML='LoadMore';
+ 		moreButton.addEventListener('click', getMoreRecords);
+ 		butDiv.appendChild(moreButton)
  		
  	}
+
+ 	// we increase by 5 both indexes as these are the new limits we require
+ 	// that will satisfy our table size
+ 	function getMoreRecords(){
+ 	 	$table.empty();
+ 	 	indexFrom = indexFrom+5;
+ 	 	indexTo = indexTo+5;
+
+ 	 	$.ajax({
+
+ 	 		type: 'GET',
+ 	 		url: 'http://localhost:8080/project/rest/failedcalldata/count/'+fromDate+'£'+toDate+'£'+indexFrom+'£'+indexTo,
+ 	 		success: function(data){
+ 	 	 			createTable();
+ 	 	 			createButton();
+ 	 	 			$.each(data, function(key, value){
+ 	 	 				$table.append('<tr><td>'+value[0]+'</td><td>'+value[1]+'</td><td>'+value[2]+'</td></tr>');
+ 	 	 	 		});
+ 	 	 	 	} 	 					
+ 	 	 });
+ 	 }
 
  	function removeData(){
  		var removeHead=document.getElementById('head');

--- a/src/main/webapp/SEPage.jsp
+++ b/src/main/webapp/SEPage.jsp
@@ -138,11 +138,13 @@
 
 
 			</div>
+			<div style="height:250px; width:800px; overflow:auto;">
+			
 			<table class="table" id='tableJohn' name='table'>
 
 
 			</table>
-
+</div>
 
 		</div>
 		<!-- /#wrapper -->
@@ -244,7 +246,7 @@ $(function(){
 	var isValid=false;
 	
 	if(validateEntry(fromDate, toDate)){	
-		myurl='http://localhost:8080/project/rest/failedcalldata/getFailedCallDataByModel/'+selected+'Â£'+fromDate+'Â£'+toDate;
+		myurl='http://localhost:8080/project/rest/failedcalldata/getFailedCallDataByModel/'+selected+'£'+fromDate+'£'+toDate;
 		isValid=true;
 		}
 
@@ -335,7 +337,7 @@ $(function(){
 			var isValid=false;
 			
 			if(validateEntry(fromDate, toDate)){	
-				myurl='http://localhost:8080/project/rest/failedcalldata/dateIMSI/'+fromDate+'Â£'+toDate;
+				myurl='http://localhost:8080/project/rest/failedcalldata/dateIMSI/'+fromDate+'£'+toDate;
 				isValid=true;
 				}
 			
@@ -400,7 +402,7 @@ $(function(){
  		var row = document.createElement('tr');
  		
  		row.setAttribute('id', 'head');
- 		
+ 		row.setAttribute('display', 'block');
  		var colOne=document.createElement('th');
 
  		colOne.innerHTML='IMSI';


### PR DESCRIPTION
One table is done via sending index values back to the rest side and
only returning data within those parameters. I dont like this way myself
as its incredibly hacky and looks ugly. The second way is cleaner and
just invoolves scrolling tables. Issues with this way include table
dimensions intersacting with scroll dimensions and I cant seem to stop
table headers from scrolliing. Paginating via criteria builder (limit
and skip not supported on JPQL) seems overly difficult and paginating
client side is headwrecking. We can decide on which method to paginate
later.
